### PR TITLE
Potential solution for printing single stepper values

### DIFF
--- a/src/main/scala/replrunner.scala
+++ b/src/main/scala/replrunner.scala
@@ -2,14 +2,25 @@ package dinocpu
 import treadle.TreadleOptionsManager
 import treadle.repl.HasReplConfig
 
+/** Wrapper object to run the treadle REPL for debugging CPU designs
+  * Use main function to call
+  */
 object replrunner {
   val helptext = "usage: replrunner <test name> <CPU type>"
 
+  /** Runs a test in an interactive environment allows single steping and reading register values
+    * params test_name CPU_type
+    * example usage
+    * {{{
+    * runMain replrunner add1 pipelined
+    * }}}
+    */
   def main(args: Array[String]): Unit = {
     require(args.length >= 2, "Error: Expected at least two argument\n" + helptext)
 
     println(s"Running test ${args(0)} on CPU design ${args(1)}")
 
+    //get the params, test name and cpu type
     val test = InstTests.nameMap(args(0))
     val params = args(1).split(":")
     val cpuType = params(0)
@@ -26,7 +37,7 @@ object replrunner {
     driver.initRegs(test.initRegs)
     driver.initMemory(test.initMem)
 
-    //create a copy of the options from the testerdriver, just as slightly different type
+    //create a copy of the options from the testerdriver, with the replconfig option
     val options = new TreadleOptionsManager with HasReplConfig
     options.treadleOptions = driver.optionsManager.treadleOptions.copy()
     options.firrtlOptions = driver.optionsManager.firrtlOptions.copy()
@@ -34,6 +45,7 @@ object replrunner {
     //copy the configured simulator in the REPL
     val repl = new treadle.TreadleRepl(options)
     repl.currentTreadleTesterOpt = Some(driver.simulator)
+
     repl.run()
 
     //check test result

--- a/src/main/scala/replrunner.scala
+++ b/src/main/scala/replrunner.scala
@@ -3,25 +3,7 @@ import treadle.TreadleOptionsManager
 import treadle.repl.HasReplConfig
 
 object replrunner {
-  val helptext = "usage: singlestep <test name> <CPU type>"
-
-  def initRegs(vals: Map[Int, BigInt],repl: treadle.TreadleRepl ) {
-    for ((num, value) <- vals) {
-      repl.currentTreadleTester.poke(s"cpu.registers.regs_$num", value)
-    }
-  }
-
-  /**
-    *
-    * @param vals holds "addresses" to values. Where address is the nth *word*
-    */
-  def initMemory(vals: Map[Int, BigInt],repl: treadle.TreadleRepl): Unit = {
-    for ((addr, value) <- vals) {
-        repl.currentTreadleTester.pokeMemory(s"cpu.mem.memory", addr, value)
-    }
-  }
-
-
+  val helptext = "usage: replrunner <test name> <CPU type>"
 
   def main(args: Array[String]): Unit = {
     require(args.length >= 2, "Error: Expected at least two argument\n" + helptext)
@@ -39,17 +21,22 @@ object replrunner {
         ""
       }
 
+    //setup test
     val driver = new CPUTesterDriver(cpuType, predictor, test.binary, test.extraName, true)
     driver.initRegs(test.initRegs)
     driver.initMemory(test.initMem)
 
+    //create a copy of the options from the testerdriver, just as slightly different type
     val options = new TreadleOptionsManager with HasReplConfig
     options.treadleOptions = driver.optionsManager.treadleOptions.copy()
     options.firrtlOptions = driver.optionsManager.firrtlOptions.copy()
 
+    //copy the configured simulator in the REPL
     val repl = new treadle.TreadleRepl(options)
     repl.currentTreadleTesterOpt = Some(driver.simulator)
     repl.run()
+
+    //check test result
     if (driver.checkRegs(test.checkRegs) && driver.checkMemory(test.checkMem)) {
       println("Test passed!")
     } else {

--- a/src/main/scala/replrunner.scala
+++ b/src/main/scala/replrunner.scala
@@ -1,0 +1,43 @@
+package dinocpu
+import dinocpu.{CPUTesterDriver, InstTests}
+import treadle.TreadleOptionsManager
+import treadle.repl.HasReplConfig
+
+object replrunner {
+  val helptext = "usage: singlestep <test name> <CPU type>"
+  def main(args: Array[String]): Unit = {
+    require(args.length >= 2, "Error: Expected at least two argument\n" + helptext)
+
+    println(s"Running test ${args(0)} on CPU design ${args(1)}")
+
+    val test = InstTests.nameMap(args(0))
+    val params = args(1).split(":")
+    val cpuType = params(0)
+
+    val predictor =
+      if (params.length == 2) {
+        params(1)
+      } else {
+        ""
+      }
+
+    val driver = new CPUTesterDriver(cpuType, predictor, test.binary, test.extraName, true)
+    driver.initRegs(test.initRegs)
+    driver.initMemory(test.initMem)
+
+    val options = new TreadleOptionsManager with HasReplConfig
+    if (options.targetDirName == ".") {
+      options.setTargetDirName(s"test_run_dir/$cpuType/$test.binary$test.extraName")
+    }
+
+    val repl = new treadle.TreadleRepl(options)
+    repl.loadSource(driver.compiledFirrtl)
+    repl.run()
+    if (driver.checkRegs(test.checkRegs) && driver.checkMemory(test.checkMem)) {
+      println("Test passed!")
+    } else {
+      println("Test failed!")
+    }
+
+  }
+}


### PR DESCRIPTION
This is one way to implement a single stepper with more features, using the treadle repl. Adds printing and writing reg values (with tab completion).

Example usage
```
runMain dinocpu.replrunner add1 pipelined
> peek cpu.if_id_instruction
> step 5
```