### PR TITLE
Scala grader

### DIFF
--- a/src/test/scala/grading/ExampleGraderScala.scala
+++ b/src/test/scala/grading/ExampleGraderScala.scala
@@ -1,0 +1,28 @@
+package dinocpu
+
+/** Example definition of graded test, runs a few tests from lab 1
+  *
+  */
+object examplegrader {
+  def main(args: Array[String]): Unit = {
+
+    //each test set appears as one test on gradescope, contains at least one InstTests
+    val sets = List[GradedTestSet](
+      new GradedTestSet("Single Cycle Add",List[CPUTestCase](InstTests.nameMap("add1")),10,true,"single-cycle"),
+      new GradedTestSet("R-type single cycle",InstTests.rtype,10,true,"single-cycle"),
+      new GradedTestSet("R-type multicycle",InstTests.rtypeMultiCycle,10,true,"single-cycle")
+    )
+    //json string to gradescope
+    var json: String = s"""{ "tests":["""
+    var results = new scala.collection.mutable.ArrayBuffer[String]()
+    //runs each test in each set and appends result to json string
+    for(set <- sets){
+      val result = set.runTests()
+      results += result.toJsonStr()
+    }
+    json += results.mkString(",")
+    //for now just print result
+    json += "]}"
+    print(json)
+  }
+}

--- a/src/test/scala/grading/GradedTest.scala
+++ b/src/test/scala/grading/GradedTest.scala
@@ -1,0 +1,51 @@
+package dinocpu
+
+/** Defines a set of tests to run for grading, to appear as one test on gradescope
+  *
+  */
+class GradedTestSet(setName: String, tests: List[CPUTestCase], maxScore: Double, partialCredit: Boolean, cpu:String, branchPredictor:String = "") {
+  var testToRun: List[CPUTestCase] = tests
+  var totalScore: Double = maxScore
+  var pc: Boolean = partialCredit
+  var name: String = setName
+  var cpuType: String = cpu
+  var bp: String = branchPredictor
+
+  /** runs all the tests defined in the set and computes the resulting score
+    *
+    * @return a GradedTestResult containing the output of the test
+    */
+  def runTests(): GradedTestResult ={
+    val result = new GradedTestResult(this)
+    for (test <- testToRun) {
+      if(CPUTesterDriver(test, cpuType, bp)){
+        result.score += totalScore / testToRun.length
+        result.output += s"Passed ${test.binary}${test.extraName}\\n"
+      } else {
+        result.output += s"Failed ${test.binary}${test.extraName} \\n"
+      }
+    }
+    result.score = (result.score * 100).round / 100.0
+
+    if(result.score != totalScore && !pc)
+      result.score = 0
+    return result
+  }
+}
+
+/** Wraps the result of a graded test, to have a field requires for gradescope
+  * @param tests corresponding graded test of this result
+  */
+class GradedTestResult(tests: GradedTestSet) {
+  var score: Double = 0.0
+  var name: String = tests.name
+  var max_score: Double = tests.totalScore
+  var output: String = ""
+
+  /** returns JSON formated string containing result of test
+    *
+    */
+  def toJsonStr(): String = {
+    return f"""{ "score": $score, "max_score": $max_score, "name": "$name", "output": "$output" }"""
+  }
+}


### PR DESCRIPTION
Some progress towards replace the grader with pure scala. Currently it is only works with cpu tests, I have to think of a way to get it for both unit tests and cpu tests.

This is the output of the example grader which runs a few of the tests.
```json
{ "tests":[
  {     
      "score": 10.0,
      "max_score": 10.0,
      "name": "Single Cycle Add",
      "output": "Passed add1\n" 
  },
  {     
      "score": 10.0,
      "max_score": 10.0, 
      "name": "R-type single cycle", 
      "output": "Passed add1\nPassed add2\nPassed add0\nPassed or\nPassed sub\nPassed and\nPassed xor\nPassed slt\nPassed slt1\nPassed sltu\nPassed sltu1\nPassed sll\nPassed srl\nPassed sra\n"
  },
  {     
      "score": 10.0, 
      "max_score": 10.0,
      "name": "R-type multicycle",
      "output": "Passed addfwd\nPassed swapxor\nPassed power2-512\nPassed power2-1234\nPassed power2--65536\nPassed oppsign-true\nPassed oppsign-false\nPassed rotR\n"
  }
]}
```