### PR TITLE
Suppress warnings in test output

### DIFF
--- a/src/main/scala/memory/base-memory-components.scala
+++ b/src/main/scala/memory/base-memory-components.scala
@@ -2,6 +2,7 @@
 
 package dinocpu.memory
 
+import dinocpu.memory.MemoryOperation._
 import chisel3._
 import chisel3.util.experimental.loadMemoryFromFile
 
@@ -22,8 +23,12 @@ abstract class BaseDualPortedMemory(size: Int, memfile: String) extends Module {
     val imem = new MemPortBusIO
     val dmem = new MemPortBusIO
   })
-  io.imem <> 0.U.asTypeOf (new MemPortBusIO)
-  io.dmem <> 0.U.asTypeOf (new MemPortBusIO)
+  // Intentional DontCares:
+  // The connections between the ports and the backing memory, along with the
+  // ports internally assigning values to the, means that these DontCares
+  // should be completely 'overwritten' when the CPU is elaborated
+  io.imem <> DontCare
+  io.dmem <> DontCare
 
   val memory = Mem(math.ceil(size.toDouble/4).toInt, UInt(32.W))
   loadMemoryFromFile(memory, memfile)
@@ -39,7 +44,11 @@ abstract class BaseIMemPort extends Module {
   })
 
   io.pipeline <> 0.U.asTypeOf (new IMemPortIO)
-  io.bus      <> 0.U.asTypeOf (new MemPortBusIO)
+  // Intentional DontCare:
+  // The connections between the ports and the backing memory, along with the
+  // ports internally assigning values to the, means that these DontCares
+  // should be completely 'overwritten' when the CPU is elaborated
+  io.bus      <> DontCare
 }
 
 /**
@@ -52,7 +61,11 @@ abstract class BaseDMemPort extends Module {
   })
 
   io.pipeline <> 0.U.asTypeOf (new DMemPortIO)
-  io.bus      <> 0.U.asTypeOf (new MemPortBusIO)
+  // Intentional DontCare:
+  // The connections between the ports and the backing memory, along with the
+  // ports internally assigning values to the, means that these DontCares
+  // should be completely 'overwritten' when the CPU is elaborated
+  io.bus      <> DontCare
 
   io.pipeline.good := io.bus.response.valid
 }

--- a/src/main/scala/memory/memory-noncombin-ports.scala
+++ b/src/main/scala/memory/memory-noncombin-ports.scala
@@ -34,7 +34,7 @@ class DNonCombinMemPort extends BaseDMemPort {
 
   // A register to hold intermediate data (e.g., write data, mask mode) while the request
   // is outstanding to memory.
-  val outstandingReq = RegInit(0.U.asTypeOf(Valid(new OutstandingReq)))
+  val outstandingReq = RegInit (0.U.asTypeOf (Valid (new OutstandingReq)))
 
   // Used to set the valid bit of the outstanding request
   val sending = Wire(Bool())

--- a/src/main/scala/memory/memory-noncombin-ports.scala
+++ b/src/main/scala/memory/memory-noncombin-ports.scala
@@ -34,7 +34,8 @@ class DNonCombinMemPort extends BaseDMemPort {
 
   // A register to hold intermediate data (e.g., write data, mask mode) while the request
   // is outstanding to memory.
-  val outstandingReq = RegInit (0.U.asTypeOf (Valid (new OutstandingReq)))
+  val outstandingReq = Reg (Valid (new OutstandingReq))
+  outstandingReq.valid := false.B
 
   // Used to set the valid bit of the outstanding request
   val sending = Wire(Bool())

--- a/src/main/scala/memory/memory-noncombin.scala
+++ b/src/main/scala/memory/memory-noncombin.scala
@@ -37,7 +37,7 @@ class DualPortedNonCombinMemory(size: Int, memfile: String, latency: Int) extend
 
   when (io.imem.request.valid) {
     // Put the Request into the instruction pipe and signal that instruction memory is busy
-    val inRequest = io.imem.request.asTypeOf(new Request)
+    val inRequest = io.imem.request.bits
     imemPipe.io.enq.bits  := inRequest
     imemPipe.io.enq.valid := true.B
   } .otherwise {
@@ -47,7 +47,7 @@ class DualPortedNonCombinMemory(size: Int, memfile: String, latency: Int) extend
   when (imemPipe.io.deq.valid) {
     // We should only be expecting a read from instruction memory
     assert(imemPipe.io.deq.bits.operation === Read)
-    val outRequest = imemPipe.io.deq.asTypeOf (new Request)
+    val outRequest = imemPipe.io.deq.bits
     // Check that address is pointing to a valid location in memory
     assert (outRequest.address < size.U)
     io.imem.response.valid        := true.B
@@ -65,7 +65,7 @@ class DualPortedNonCombinMemory(size: Int, memfile: String, latency: Int) extend
 
   when (io.dmem.request.valid) {
     // Put the Request into the data pipe and signal that data memory is busy
-    val inRequest = io.dmem.request.asTypeOf (new Request)
+    val inRequest = io.dmem.request.bits
     dmemPipe.io.enq.bits  := inRequest
     dmemPipe.io.enq.valid := true.B
   } .otherwise {
@@ -75,7 +75,7 @@ class DualPortedNonCombinMemory(size: Int, memfile: String, latency: Int) extend
   when (dmemPipe.io.deq.valid) {
     assert (dmemPipe.io.deq.bits.operation =/= ReadWrite)
     // Dequeue request and execute
-    val outRequest = dmemPipe.io.deq.asTypeOf (new Request)
+    val outRequest = dmemPipe.io.deq.bits
     val address = outRequest.address >> 2
     // Check that address is pointing to a valid location in memory
     assert (outRequest.address < size.U)

--- a/src/main/scala/memory/memory.scala
+++ b/src/main/scala/memory/memory.scala
@@ -24,7 +24,7 @@ class DualPortedCombinMemory(size: Int, memfile: String) extends BaseDualPortedM
 
   when (io.imem.request.valid) {
     // Put the Request into the instruction pipe and signal that instruction memory is busy
-    val request = io.imem.request.asTypeOf(new Request)
+    val request = io.imem.request.bits
 
     // We should only be expecting a read from instruction memory
     assert(request.operation === Read)
@@ -50,7 +50,7 @@ class DualPortedCombinMemory(size: Int, memfile: String) extends BaseDualPortedM
   val memWriteData = io.dmem.request.bits.writedata
 
   when (io.dmem.request.valid) {
-    val request = io.dmem.request.asTypeOf (new Request)
+    val request = io.dmem.request.bits
 
     // Check that non-combin write isn't being used
     assert (request.operation =/= Write)

--- a/src/main/scala/pipelined/stage-register.scala
+++ b/src/main/scala/pipelined/stage-register.scala
@@ -21,15 +21,16 @@ class StageRegIO[+T <: Data](gen: T) extends Bundle {
 
   /** The outputted data from the internal register */
   val data = Output(gen)
+
+  override def cloneType: this.type = StageRegIO (gen).asInstanceOf[this.type]
 }
 
 /**
   * Factory to wrap a data bundle in a stage register IO interface.
   */
 object StageRegIO {
-  def apply[T <: Data](gen: T): StageRegIO[T] = new StageRegIO(gen)
+  def apply[T <: Data](gen: T): StageRegIO[T] = new StageRegIO (gen)
 }
-
 
 /** A specialized register module that supports freezing, flushing,
   * and writing to its contents when valid.


### PR DESCRIPTION
This PR addresses #96 by fixing a few bugs regarding the elaboration of the CPU models. Once complete, all warnings about `MemoryOperation` casting and the `StageReg` clone type should no longer show up.

This helps to clear up the testing log and allow people to locate any erroneous register values or failed tests.