### PR TITLE
Fixes for the problem where two TargetDirAnnotation cause Driver.execute to fail.

### DIFF
--- a/src/main/scala/simulate.scala
+++ b/src/main/scala/simulate.scala
@@ -75,8 +75,6 @@ object simulate {
 
   def build(optionsManager: SimulatorOptionsManager, conf: CPUConfig): String = {
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
-    val annos = firrtl.Driver.getAnnotations(optionsManager)
-    optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
 
     chisel3.Driver.execute(optionsManager, () => new Top(conf)) match {
     case ChiselExecutionSuccess(Some(_), _, Some(firrtlExecutionResult)) =>

--- a/src/main/scala/testing/CPUTesterDriver.scala
+++ b/src/main/scala/testing/CPUTesterDriver.scala
@@ -21,9 +21,7 @@ class CPUTesterDriver(cpuType: String,
   val optionsManager = new SimulatorOptionsManager()
 
   if (optionsManager.targetDirName == ".") {
-    // TODO: Revert this either by waiting for the chisel guys to fix the CWD bug, or moving the testing system over to
-    // FIRRTLMain instead of Driver
-    //optionsManager.setTargetDirName(s"test_run_dir/$cpuType/$binary$extraName")
+    optionsManager.setTargetDirName(s"test_run_dir/$cpuType/$binary$extraName")
   }
 
   val hexName = s"${optionsManager.targetDirName}/${binary}.hex"


### PR DESCRIPTION
This eliminates an, I believe, unnecessary call to `getAnnotations` which is causing the duplication.
`getAnnotations` is used internally by `Driver.execute` and it is where the `TargetDirAnnotation` is added.
I heard a report you were having this problem. It looks like you may already be trying to move to state /phase so this may not be necessary. Let me know if you have questions.