### PR TITLE
Fix incorrect disassembly of LUI and AUIPC instructions

### DIFF
--- a/src/main/scala/utils/disassembler.scala
+++ b/src/main/scala/utils/disassembler.scala
@@ -156,14 +156,14 @@ object Disassembler {
     *
     */
   def parseAuipc(instr:Instruction):String={
-    "lui x" + instr.rd + " " + instr.uImm
+    "auipc x" + instr.rd + " " + instr.uImm
   }
 
   /** Decodes Lui instruction
     *
     */
   def parseLui(instr:Instruction):String={
-    "auipc x" + instr.rd + " " + instr.uImm
+    "lui x" + instr.rd + " " + instr.uImm
   }
 
   /** Disassembles any of the RV32I instructions
@@ -181,8 +181,8 @@ object Disassembler {
       case BRANCH_OPCODE => parseBranch(instr)
       case JAR_OPCODE => parseJal(instr)
       case JALR_OPCODE => parseJalr(instr)
-      case AUIPC_OPCODE => parseBranch(instr)
-      case LUI_OPCODE => parseBranch(instr)
+      case AUIPC_OPCODE => parseAuipc(instr)
+      case LUI_OPCODE => parseLui(instr)
       case _ => "Unknown"
     }
   }


### PR DESCRIPTION
As title. Using `sbt:dinocpu> runMain dinocpu.singlestep auipc0 0` as an example.
Before:
```
Single stepper> print inst
0       : beq x0, x0, pc + 10  (0x00000517)
```
After:
```
Single stepper> print inst
0       : auipc x10 0          (0x00000517)```