### PR TITLE
[Doc] add missing package name in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To compile your Chisel design into Verilog, you can run the `elaborate` main fun
 As an example:
 
 ```
-sbt:dinocpu> runMain elaborate single-cycle
+sbt:dinocpu> runMain dinocpu.elaborate single-cycle
 ```
 The generated verilog will be available in the root folder as `Top.v` along with some meta-data. You may also get some generated verilog for auxillary devices like memory as `Top.<device_name>.v`
 


### PR DESCRIPTION
I think the package name is needed, otherwise `sbt` won't find the elaborate. This is the error trace.

```
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Packaging /Users/vega/z/code/dinocpu/target/scala-2.12/dinocpu_2.12-0.5.jar ...
[info] Done packaging.
[info] Running elaborate single-cycle
[error] (run-main-0) java.lang.ClassNotFoundException: elaborate
[error] java.lang.ClassNotFoundException: elaborate
[error] 	at java.base/java.lang.ClassLoader.findClass(ClassLoader.java:718)
[error] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
[error] Nonzero exit code: 1
[error] (Compile / runMain) Nonzero exit code: 1
[error] Total time: 21 s, completed Mar 5, 2020, 8:36:32 PM
```