### PR TITLE
Fix register-file component writeback bug

### DIFF
--- a/src/main/scala/components/register-file.scala
+++ b/src/main/scala/components/register-file.scala
@@ -66,7 +66,8 @@ class RegisterFile(implicit val conf: CPUConfig) extends Module {
     // For the five-cycle and pipelined CPU forward the data through the register file
     when (io.readreg1 === io.writereg && io.wen) {
       io.readdata1 := io.writedata
-    } .elsewhen (io.readreg2 === io.writereg && io.wen) {
+    }
+    when (io.readreg2 === io.writereg && io.wen) {
       io.readdata2 := io.writedata
     }
   }


### PR DESCRIPTION
When an instruction is at the writeback stage, the register file
component would forward the write data to the outputs if the
register being written to is also the register being read.

Currently, if the register being written to is also being read,
the component only forwards the write data to exactly one of the
outputs {readdata1, readdata2}. However, it is possible for an
instruction to have rs1 === rs2 (e.g. sw x5, -8(x5)), and in this
case, the writedata should be forwarded to both readdata1 and
readdata2.

This change fixes that issue by allowing forwarding to both
readdata1 and readdata2 if rs1 === rs2 === writereg.

Signed-off-by: Hoa Nguyen <hoanguyen@ucdavis.edu>