### PR TITLE
The width of PC of single cycle cpu is left undefined (#147)

### DIFF
--- a/src/main/scala/single-cycle/cpu.scala
+++ b/src/main/scala/single-cycle/cpu.scala
@@ -14,7 +14,7 @@ import dinocpu.components._
  */
 class SingleCycleCPU(implicit val conf: CPUConfig) extends BaseCPU {
   // All of the structures required
-  val pc         = dontTouch(RegInit(0.U))
+  val pc         = dontTouch(RegInit(0.U(32.W)))
   val control    = Module(new Control())
   val registers  = Module(new RegisterFile())
   val aluControl = Module(new ALUControl())


### PR DESCRIPTION
This means FIRRTL compiler will infer the bit width of PC. It is shown in the verilog presentation that FIRRTL optimized the PC width to 5. That results in the single cycle CPU to not to cause any error for small application. However, when run with large applications, the PC reached 0x1ffc and looped back to 0 for the next PC.

This patch, by explicitly defining the width of PC, prevents the FIRRTL complier from over-optimizing the width.

Essentially, width inferences cause design issues. Don't do it.

Signed-off-by: Hoa Nguyen <hoanguyen@ucdavis.edu>