### PR TITLE
Fix the width of pc of single-cycle cpu

### DIFF
--- a/src/main/scala/components/branchpred.scala
+++ b/src/main/scala/components/branchpred.scala
@@ -16,7 +16,7 @@ import dinocpu._
  * Output: prediction, true if the branch is predicted to be taken, false otherwise
  */
 class BranchPredIO extends Bundle {
-  val pc         = Input(UInt(32.W))
+  val pc         = Input(UInt(64.W))
   val update     = Input(Bool())
   val taken      = Input(Bool())
 

--- a/src/main/scala/single-cycle/cpu.scala
+++ b/src/main/scala/single-cycle/cpu.scala
@@ -14,7 +14,7 @@ import dinocpu.components._
  */
 class SingleCycleCPU(implicit val conf: CPUConfig) extends BaseCPU {
   // All of the structures required
-  val pc         = dontTouch(RegInit(0.U(32.W)))
+  val pc         = dontTouch(RegInit(0.U(64.W)))
   val control    = Module(new Control())
   val registers  = Module(new RegisterFile())
   val aluControl = Module(new ALUControl())


### PR DESCRIPTION
Should be 64 bits long.

Signed-off-by: Hoa Nguyen <hoanguyen@ucdavis.edu>