### PR TITLE
Fix hexadecimal value conversions when dumping modules

### DIFF
--- a/src/main/scala/testing/CPUTesterDriver.scala
+++ b/src/main/scala/testing/CPUTesterDriver.scala
@@ -107,7 +107,7 @@ class CPUTesterDriver(cpuType: String,
     for (name <- modules) {
       for ((symbol, name) <- getIO(name)) {
         val v = simulator.peek(symbol)
-        println(s"${name.padTo(30, ' ')} ${v} (0x${v.toInt.toHexString})")
+        println(s"${name.padTo(30, ' ')} ${v} (0x${v.toLong.toHexString})")
       }
     }
   }
@@ -133,7 +133,7 @@ class CPUTesterDriver(cpuType: String,
   def dumpModule(module: String): Unit = {
     for ((symbol, name) <- getIO(module)) {
       val v = simulator.peek(symbol)
-      println(s"${name.padTo(30, ' ')} ${v} (0x${v.toInt.toHexString})")
+      println(s"${name.padTo(30, ' ')} ${v} (0x${v.toLong.toHexString})")
     }
   }
 
@@ -149,7 +149,7 @@ class CPUTesterDriver(cpuType: String,
     for (sym <- syms) {
       val name = s"${module}.${sym.split('.').last.drop(4)}"
       val v = simulator.peek(sym)
-      println(s"${name.padTo(39, ' ')} ${v} (0x${v.toInt.toHexString})")
+      println(s"${name.padTo(39, ' ')} ${v} (0x${v.toLong.toHexString})")
     }
 
    val inputs = simulator.engine.validNames.filter(
@@ -157,7 +157,7 @@ class CPUTesterDriver(cpuType: String,
     for (sym <- inputs) {
       val name = s"${module}.${sym.split('.').last.drop(4)}".dropRight(3) + " (input)"
       val v = simulator.peek(sym)
-      println(s"${name.padTo(40, ' ')}${v} (0x${v.toInt.toHexString})")
+      println(s"${name.padTo(40, ' ')}${v} (0x${v.toLong.toHexString})")
     }
 
   }


### PR DESCRIPTION
Currently, to get the hexadecimal representation of each signal (of type BigInt) of a module, values of the signals are converted to scala's Int type (32 bits long) before they are converted to strings. However, since we are dealing with 64-bit architectures, data and addresses are 64 bits long. So, we should convert BigInt to the Long type (64-bit integer) instead of Int.

Signed-off-by: Hoa Nguyen <hoanguyen@ucdavis.edu>